### PR TITLE
feat: add missing cypress.run options (closes #6)

### DIFF
--- a/lib/src/cypress/cypress-builder.ts
+++ b/lib/src/cypress/cypress-builder.ts
@@ -30,6 +30,12 @@ export interface CypressBuilderOptions {
   env?: object;
   host?: string;
   port?: number;
+  ciBuildId?: string;
+  group?: string;
+  key?: string;
+  parallel?: boolean;
+  record?: boolean;
+  spec?: string;
 }
 
 export class CypressBuilder implements Builder<CypressBuilderOptions> {
@@ -118,7 +124,13 @@ export class CypressBuilder implements Builder<CypressBuilderOptions> {
       },
       ...(options.project ? { project: options.project } : {}),
       ...(options.reporterPath ? { reporter: options.reporterPath } : {}),
-      ...(options.env ? { env: options.env } : {})
+      ...(options.env ? { env: options.env } : {}),
+      ...(options.ciBuildId ? { ciBuildId: options.ciBuildId } : {}),
+      ...(options.group ? { group: options.group } : {}),
+      ...(options.key ? { key: options.key } : {}),
+      ...(options.parallel ? { parallel: options.parallel } : {}),
+      ...(options.record ? { record: options.record } : {}),
+      ...(options.spec ? { spec: options.spec } : {}),
     };
     const cypress = require("cypress");
     const runner =

--- a/lib/src/cypress/cypress-builder.ts
+++ b/lib/src/cypress/cypress-builder.ts
@@ -23,18 +23,19 @@ export enum CypressRunningMode {
 
 export interface CypressBuilderOptions {
   devServerTarget?: string;
-  project?: string;
   mode?: string;
-  reporterPath?: string;
   baseUrl?: string;
-  env?: object;
   host?: string;
-  port?: number;
   ciBuildId?: string;
+  env?: object;
   group?: string;
   key?: string;
   parallel?: boolean;
+  port?: number;
+  project?: string;
   record?: boolean;
+  reporter?: string;
+  reporterPath?: string;
   spec?: string;
 }
 
@@ -122,15 +123,16 @@ export class CypressBuilder implements Builder<CypressBuilderOptions> {
       config: {
         baseUrl: options.baseUrl
       },
-      ...(options.project ? { project: options.project } : {}),
-      ...(options.reporterPath ? { reporter: options.reporterPath } : {}),
-      ...(options.env ? { env: options.env } : {}),
       ...(options.ciBuildId ? { ciBuildId: options.ciBuildId } : {}),
+      ...(options.env ? { env: options.env } : {}),
       ...(options.group ? { group: options.group } : {}),
       ...(options.key ? { key: options.key } : {}),
       ...(options.parallel ? { parallel: options.parallel } : {}),
+      ...(options.project ? { project: options.project } : {}),
       ...(options.record ? { record: options.record } : {}),
-      ...(options.spec ? { spec: options.spec } : {}),
+      ...(options.reporter ? { reporter: options.reporter } : {}),
+      ...(options.reporterPath ? { reporter: options.reporterPath } : {}),
+      ...(options.spec ? { spec: options.spec } : {})
     };
     const cypress = require("cypress");
     const runner =

--- a/lib/src/cypress/schema.json
+++ b/lib/src/cypress/schema.json
@@ -7,19 +7,6 @@
       "type": "string",
       "description": "Dev server target to run tests against."
     },
-    "baseUrl": {
-      "type": "string",
-      "description": "Base URL for Cypress to connect to."
-    },
-    "port": {
-      "type": "number",
-      "description": "The port to use to serve the application."
-    },
-    "host": {
-      "type": "string",
-      "description": "Host to listen on.",
-      "default": "localhost"
-    },
     "mode": {
       "type": "string",
       "enum": [
@@ -29,17 +16,22 @@
       "description": "Run mode of Cypress. Valid value are 'console' and 'browser'",
       "default": "console"
     },
-    "reporterPath": {
+    "baseUrl": {
       "type": "string",
-      "description": "Relative path to the reporter based the project root"
+      "description": "Base URL for Cypress to connect to."
     },
-    "env": {
-      "type": "object",
-      "description": "Environment variable"
+    "host": {
+      "type": "string",
+      "description": "Host to listen on.",
+      "default": "localhost"
     },
     "ciBuildId": {
       "type": "string",
       "description": "Specify a unique identifier for a run to enable grouping or parallelization"
+    },
+    "env": {
+      "type": "object",
+      "description": "Environment variable"
     },
     "group": {
       "type": "string",
@@ -53,6 +45,10 @@
       "type": "boolean",
       "description": "Run recorded specs in parallel across multiple machines"
     },
+    "port": {
+      "type": "number",
+      "description": "The port to use to serve the application."
+    },
     "project": {
       "type": "string",
       "description": "Path to a specific project"
@@ -60,6 +56,14 @@
     "record": {
       "type": "boolean",
       "description": "Whether to record and upload the test run to Cypress Dashboard"
+    },
+    "reporter": {
+      "type": "string",
+      "description": "Specify a Mocha reporter"
+    },
+    "reporterPath": {
+      "type": "string",
+      "description": "Relative path to the reporter based the project root"
     },
     "spec": {
       "type": "string",

--- a/lib/src/cypress/schema.json
+++ b/lib/src/cypress/schema.json
@@ -26,7 +26,7 @@
         "console",
         "browser"
       ],
-      "description": "Run mode of Cypress. Valid value are 'console' and 'browser' ",
+      "description": "Run mode of Cypress. Valid value are 'console' and 'browser'",
       "default": "console"
     },
     "reporterPath": {
@@ -36,6 +36,34 @@
     "env": {
       "type": "object",
       "description": "Environment variable"
+    },
+    "ciBuildId": {
+      "type": "string",
+      "description": "Specify a unique identifier for a run to enable grouping or parallelization"
+    },
+    "group": {
+      "type": "string",
+      "description": "Group recorded tests together under a single run"
+    },
+    "key": {
+      "type": "string",
+      "description": "Specify your secret record key"
+    },
+    "parallel": {
+      "type": "boolean",
+      "description": "Run recorded specs in parallel across multiple machines"
+    },
+    "project": {
+      "type": "string",
+      "description": "Path to a specific project"
+    },
+    "record": {
+      "type": "boolean",
+      "description": "Whether to record and upload the test run to Cypress Dashboard"
+    },
+    "spec": {
+      "type": "string",
+      "description": "Specify the specs to run"
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
Added `record` (#6) and a few other arguments available for `run()`

Edit: I initially thought this did not work when testing locally after switching devices and was completely stumped - turns out I added all of the properties to the production configuration in `angular.json` 🤦‍♀️ 