### PR TITLE
Handle watch mode on devServerTarget based on Cypress running mode

### DIFF
--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-cypress-builder",
-  "version": "0.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-cypress-builder",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Extensible Builder for the Angular CLI suitable not only for Angular Elements.",
   "license": "MIT",
   "repository": {

--- a/lib/src/cypress/cypress-builder.ts
+++ b/lib/src/cypress/cypress-builder.ts
@@ -68,8 +68,9 @@ export class CypressBuilder implements Builder<CypressBuilderOptions> {
       targetName,
       configuration
     ] = (options.devServerTarget as string).split(":");
-    // Override browser build watch setting.
-    const overrides = { watch: false, host: options.host, port: options.port };
+    // use browser build watch setting based on cypress running mode
+    const watchMode = options.mode === CypressRunningMode.Browser;
+    const overrides = { watch: watchMode, host: options.host, port: options.port };
     const targetSpec = {
       project,
       target: targetName,


### PR DESCRIPTION
I have been using this configuration
```
"e2e": {
          "builder": "ngx-cypress-builder:cypress",
          "options": {
            "devServerTarget": "web-app:serve",
            "mode": "browser"
          },
          "configurations": {
            "production": {
              "devServerTarget": "web-app:serve:production"
            }
          }
        }
```

and on my CI system `ng e2e -- --mode console`. 
The problem it is that when I working in BDD approach using the Cypress Browser mode, when I made changes the devServerTarget task not reload the browser.
